### PR TITLE
[TI-26] 특정 회차 선택 후 예매하기 버튼 클릭시 해당 회차의 모든 좌석정보들을 보내준다.

### DIFF
--- a/src/main/java/org/programmers/interparkyu/hall/dto/SeatResponse.java
+++ b/src/main/java/org/programmers/interparkyu/hall/dto/SeatResponse.java
@@ -1,0 +1,24 @@
+package org.programmers.interparkyu.hall.dto;
+
+import lombok.Builder;
+import org.programmers.interparkyu.hall.Seat;
+import org.programmers.interparkyu.hall.Section;
+
+public record SeatResponse(
+    Long seatId,
+    Section section,
+    Integer sectionSeatNumber,
+    Integer price
+) {
+    @Builder
+    public SeatResponse { }
+
+    public static SeatResponse from(Seat seat) {
+        return SeatResponse.builder()
+            .seatId(seat.getId())
+            .section(seat.getSection())
+            .sectionSeatNumber(seat.getSectionSeatNumber())
+            .price(seat.getPrice())
+            .build();
+    }
+}

--- a/src/main/java/org/programmers/interparkyu/hall/repository/HallRepository.java
+++ b/src/main/java/org/programmers/interparkyu/hall/repository/HallRepository.java
@@ -1,6 +1,7 @@
-package org.programmers.interparkyu.hall;
+package org.programmers.interparkyu.hall.repository;
 
 import java.util.Optional;
+import org.programmers.interparkyu.hall.Hall;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HallRepository extends JpaRepository<Hall, Long> {

--- a/src/main/java/org/programmers/interparkyu/hall/repository/SeatRepository.java
+++ b/src/main/java/org/programmers/interparkyu/hall/repository/SeatRepository.java
@@ -1,0 +1,7 @@
+package org.programmers.interparkyu.hall.repository;
+
+import org.programmers.interparkyu.hall.Seat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+}

--- a/src/main/java/org/programmers/interparkyu/hall/service/HallService.java
+++ b/src/main/java/org/programmers/interparkyu/hall/service/HallService.java
@@ -1,8 +1,9 @@
-package org.programmers.interparkyu.hall;
+package org.programmers.interparkyu.hall.service;
 
 import java.text.MessageFormat;
-import java.util.Optional;
 import org.programmers.interparkyu.error.exception.NotFoundException;
+import org.programmers.interparkyu.hall.Hall;
+import org.programmers.interparkyu.hall.repository.HallRepository;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/org/programmers/interparkyu/hall/service/SeatService.java
+++ b/src/main/java/org/programmers/interparkyu/hall/service/SeatService.java
@@ -1,0 +1,28 @@
+package org.programmers.interparkyu.hall.service;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.programmers.interparkyu.hall.dto.SeatResponse;
+import org.programmers.interparkyu.error.exception.NotFoundException;
+import org.programmers.interparkyu.hall.repository.SeatRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class SeatService {
+
+    private final SeatRepository repository;
+
+    @Transactional(readOnly = true)
+    public SeatResponse findById(Long seatId) {
+        return SeatResponse.from(repository.findById(seatId).orElseThrow(() -> {
+            throw new NotFoundException(String.format("Wrong Seat ID is given %s", seatId));
+        }));
+    }
+
+    @Transactional(readOnly = true)
+    public List<SeatResponse> getAllSeat() {
+        return repository.findAll().stream().map(SeatResponse::from).toList();
+    }
+}

--- a/src/main/java/org/programmers/interparkyu/performance/service/AdminPerformanceService.java
+++ b/src/main/java/org/programmers/interparkyu/performance/service/AdminPerformanceService.java
@@ -5,7 +5,7 @@ import static org.programmers.interparkyu.utils.TimeUtil.toLocalDate;
 import java.text.MessageFormat;
 import lombok.AllArgsConstructor;
 import org.programmers.interparkyu.error.exception.NotFoundException;
-import org.programmers.interparkyu.hall.HallService;
+import org.programmers.interparkyu.hall.service.HallService;
 import org.programmers.interparkyu.performance.Performance;
 import org.programmers.interparkyu.performance.PerformanceCategory;
 import org.programmers.interparkyu.performance.dto.PerformanceModifyRequest;

--- a/src/main/java/org/programmers/interparkyu/roundSeat/RoundSeatController.java
+++ b/src/main/java/org/programmers/interparkyu/roundSeat/RoundSeatController.java
@@ -1,0 +1,31 @@
+package org.programmers.interparkyu.roundSeat;
+
+import static org.programmers.interparkyu.roundSeat.RoundSeatController.roundSeatRequestBaseUri;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.programmers.interparkyu.ApiResponse;
+import org.programmers.interparkyu.hall.service.SeatService;
+import org.programmers.interparkyu.roundSeat.dto.RoundSeatResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping(roundSeatRequestBaseUri)
+public class RoundSeatController {
+
+    public static final String roundSeatRequestBaseUri = "/v1/roundSeats";
+
+    private final RoundSeatService roundSeatService;
+
+    private final SeatService seatService;
+
+    @GetMapping("/{roundId}")
+    public ApiResponse<List<RoundSeatResponse>> allRoundSeat(@PathVariable Long roundId) {
+        return ApiResponse.ok(String.format("%s/%s", roundSeatRequestBaseUri, roundId),
+            roundSeatService.getAllRoundSeatByRoundId(roundId));
+    }
+}

--- a/src/main/java/org/programmers/interparkyu/roundSeat/RoundSeatRepository.java
+++ b/src/main/java/org/programmers/interparkyu/roundSeat/RoundSeatRepository.java
@@ -1,0 +1,11 @@
+package org.programmers.interparkyu.roundSeat;
+
+import java.util.List;
+import org.programmers.interparkyu.RoundSeat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface RoundSeatRepository extends JpaRepository<RoundSeat, Long> {
+    @Query("select rs from RoundSeat rs join fetch rs.seat")
+    List<RoundSeat> findAllByRoundId(Long roundId);
+}

--- a/src/main/java/org/programmers/interparkyu/roundSeat/RoundSeatService.java
+++ b/src/main/java/org/programmers/interparkyu/roundSeat/RoundSeatService.java
@@ -1,0 +1,28 @@
+package org.programmers.interparkyu.roundSeat;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.programmers.interparkyu.RoundSeat;
+import org.programmers.interparkyu.hall.Seat;
+import org.programmers.interparkyu.hall.repository.SeatRepository;
+import org.programmers.interparkyu.roundSeat.dto.RoundSeatResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class RoundSeatService {
+
+    private final RoundSeatRepository roundSeatRepository;
+
+    private final SeatRepository seatRepository;
+
+    @Transactional(readOnly = true)
+    public List<RoundSeatResponse> getAllRoundSeatByRoundId(Long roundId) {
+        List<RoundSeat> roundSeats = roundSeatRepository.findAllByRoundId(roundId);
+        return roundSeats.stream().map(roundSeat -> {
+            Seat seat = roundSeat.getSeat();
+            return RoundSeatResponse.from(seat, roundSeat);
+        }).toList();
+    }
+}

--- a/src/main/java/org/programmers/interparkyu/roundSeat/dto/RoundSeatResponse.java
+++ b/src/main/java/org/programmers/interparkyu/roundSeat/dto/RoundSeatResponse.java
@@ -1,0 +1,30 @@
+package org.programmers.interparkyu.roundSeat.dto;
+
+import lombok.Builder;
+import org.programmers.interparkyu.ReservationStatus;
+import org.programmers.interparkyu.RoundSeat;
+import org.programmers.interparkyu.hall.Seat;
+import org.programmers.interparkyu.hall.Section;
+
+public record RoundSeatResponse(
+    Long id,
+    ReservationStatus reservationStatus,
+    Long seatId,
+    Section section,
+    Integer sectionSeatNumber,
+    Integer price
+) {
+    @Builder
+    public RoundSeatResponse { }
+
+    public static RoundSeatResponse from(Seat seat, RoundSeat roundSeat) {
+        return RoundSeatResponse.builder()
+            .id(roundSeat.getId())
+            .reservationStatus(roundSeat.getReservationStatus())
+            .seatId(seat.getId())
+            .section(seat.getSection())
+            .sectionSeatNumber(seat.getSectionSeatNumber())
+            .price(seat.getPrice())
+            .build();
+    }
+}

--- a/src/test/java/org/programmers/interparkyu/performance/controller/AdminPerformanceControllerTest.java
+++ b/src/test/java/org/programmers/interparkyu/performance/controller/AdminPerformanceControllerTest.java
@@ -9,11 +9,10 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.programmers.interparkyu.hall.Hall;
-import org.programmers.interparkyu.hall.HallRepository;
+import org.programmers.interparkyu.hall.repository.HallRepository;
 import org.programmers.interparkyu.performance.Performance;
 import org.programmers.interparkyu.performance.dto.PerformanceCreateRequest;
 import org.programmers.interparkyu.performance.dto.PerformanceCreateResponse;

--- a/src/test/java/org/programmers/interparkyu/roundSeat/RoundSeatRestControllerTest.java
+++ b/src/test/java/org/programmers/interparkyu/roundSeat/RoundSeatRestControllerTest.java
@@ -1,0 +1,78 @@
+package org.programmers.interparkyu.roundSeat;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.programmers.interparkyu.ReservationStatus;
+import org.programmers.interparkyu.performance.Performance;
+import org.programmers.interparkyu.performance.Round;
+import org.programmers.interparkyu.performance.dto.RoundInfo;
+import org.programmers.interparkyu.performance.repository.RoundRepository;
+import org.programmers.interparkyu.performance.repository.UserPerformanceRepository;
+import org.programmers.interparkyu.performance.service.RoundService;
+import org.programmers.interparkyu.roundSeat.dto.RoundSeatResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+class RoundSeatRestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserPerformanceRepository userPerformanceRepository;
+
+    @Autowired
+    private RoundService roundService;
+
+    @Autowired
+    private RoundSeatService roundSeatService;
+
+    @Test
+    @DisplayName("어떤 공연의 한 회차가 선택되었을 때, 해당 회차의 좌석 정보를 정상적으로 받아올 수 있다")
+    void getAllRoundSeatsOfRoundOfPerformance() throws Exception {
+        List<Performance> performances = userPerformanceRepository.findAll();
+        Performance performance = performances.get(0);
+        List<RoundInfo> rounds = roundService.getAllRoundByPerformanceId(performance.getId());
+        // TODO 2021.10.30 TI-26 : 여기서 회차의 ID를 받아올 수 있어야 한다. 이후 추가하면 rounds에서 하나의 회차를 골라 그 ID를 사용하도록 수정한다.
+        //                         현재는 ID를 받아오지 않으므로 임의로 직접 설정해준다.
+        //                         이후 테스트 메서드 내에서 값을 넣어줄 수 있으면 검증하는 값들을 정확하게 확인하도록 수정하자.
+
+        mockMvc.perform(get("/v1/roundSeats/5") // 임의로 "삶은계란구운계란" 공연의 4회차 공연을 선택
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data[0][0].id")
+                .isNumber()
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data[0][0].reservationStatus")
+                .isString()
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data[0][0].seatId")
+                .isNumber()
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data[0][0].section")
+                .isString()
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data[0][0].sectionSeatNumber")
+                .isNumber()
+            )
+            .andExpect(MockMvcResultMatchers.jsonPath("$.data[0][0].price")
+                .isNumber()
+            )
+            .andDo(print());
+    }
+
+}


### PR DESCRIPTION
* 선택된 공연의 회차에 (예매 가능한) 좌석 정보 조회 기능 구현 (모든 좌석 정보를 내려줌)

* 예매 가능한 좌석 정보만 보내주고, 그 외의 정보는 보내주지 않는 방법도 있음
  * 그러면 이 경우에는 API 반환 데이터에 좌석 끝번호 등의 데이터들을 덧붙여서 보내주어야 할 듯 하다.