### PR TITLE
[TI-112] git hook 관리를 위해 husky 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,5 @@ buildNumber.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,intellij,java
 .env
+
+/node_modules

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+Font_RED='\033[91m'
+Font_CLEAR='\033[0m' # No Color
+
+
+PREFIX_LIST=( 
+ [Feature]=1
+ [Refactor]=1
+ [Fix]=1
+ [Test]=1
+ [Chore]=1
+)
+
+if [ -z "$BRANCHES_TO_SKIP" ]; then
+  BRANCHES_TO_SKIP=("main" "develop" "release" "hotfix")
+fi
+
+BRANCH_NAME=$(git symbolic-ref --short HEAD)
+BRANCH_NAME="${BRANCH_NAME##*/}"
+JIRA_ID=`echo $BRANCH_NAME | egrep -o '^\w.-[0-9]+'`
+JIRA_ID=`echo $JIRA_ID | tr '[:lower:]' '[:upper:]'`
+
+COMMIT_MESSAGE="$(cat $1)"
+
+PREFIX=`echo $COMMIT_MESSAGE | cut -d ':' -f1 | sed 's/ *$//g'`
+MESSAGE=`echo $COMMIT_MESSAGE | cut -d ':' -f2`
+
+BRANCH_EXCLUDED=$(printf "%s\n" "${BRANCHES_TO_SKIP[@]}" | grep -c "^$BRANCH_NAME$")
+BRANCH_IN_COMMIT=$(grep -c "$JIRA_ID" $1)
+
+TICKET=[$(git rev-parse --abbrev-ref HEAD | grep -Eo '^(\w+/)?(\w+[-_ ])?[0-9]+' | grep -Eo '(\w+[-])?[0-9]+' | tr "[:lower:]" "[:upper:]")]
+
+if [[ $TICKET == "[]" || "$COMMIT_MESSAGE" == "$TICKET"* ]];then
+  exit 0;
+fi
+
+if ! [[ "$COMMIT_MESSAGE" =~ ":" ]];then
+    printf "${Font_RED}Prefix 구분을 위해 : (세미콜론)이 필요합니다.${Font_CLEAR}\n"
+    exit 1
+fi
+
+if [[ -z ${PREFIX_LIST[$PREFIX]} ]]; then
+    printf "${Font_RED}[${PREFIX}] 는 존재 하지 않는 Prefix 입니다.${Font_CLEAR}\n"
+    echo  "사용가능한 Prefix 목록"
+    printf '%s\n' "${!PREFIX_LIST[@]}"
+    exit 1
+fi
+
+if [ -n $JIRA_ID ] && ! [[ $BRANCH_EXCLUDED -eq 1 ]] && ! [[ $BRANCH_IN_COMMIT -ge 1 ]]; then 
+  echo "[$JIRA_ID] $PREFIX: $MESSAGE" > $1
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,32 @@
+{
+  "name": "BEDV1_Interparkyu",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "husky": "^7.0.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "7.0.4",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
+    }
+  },
+  "dependencies": {
+    "husky": {
+      "version": "7.0.4",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "prepare": "husky install"
+  },
+  "devDependencies": {
+    "husky": "^7.0.0"
+  }
+}


### PR DESCRIPTION
## Git commit 이슈 번호 자동화
[Husky 깃헙 블로그](https://typicode.github.io/husky/#/)
  > 예시

  barnch: Feature/TI-123
  
  commit message :  [TI-45] Feature: 커밋 메시지

## husky 적용
> node 가 설치되어 있어야 합니다.
```
npm install
```

[TI-45]: https://kdt-gyu-ticketing-clone.atlassian.net/browse/TI-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ